### PR TITLE
Add accessTokenExpiresIn field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 1.0.0
 
 - Initial release of the Token Handler Assistant library
+
+## 1.1.0
+
+- Add `accessTokenExpiresIn` in responses to `session()`, `refresh()` and `endLogin()` functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Token Handler Assistant Changelog
 
-## 1.0.0
+## [1.0.0] - 2024-06-13
 
 - Initial release of the Token Handler Assistant library
 
-## 1.1.0
+## [Unreleased]
 
 - Add `accessTokenExpiresIn` in responses to `session()`, `refresh()` and `endLogin()` functions.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The `Configuration` object contains the following options:
    const url = new URL(location.href)
    const response = await client.endLogin({ searchParams: url.searchParams })
    if (response.isLoggedIn) {
-    // use id token claims to get username, e.g. response.idTokenClaims?.sub
+     // use id token claims to get username, e.g. response.idTokenClaims?.sub
    }
    ``` 
 Note: The `endLogin` function should only be called with authorization response parameters (when the authorization
@@ -64,7 +64,7 @@ on every load of the SPA. This function makes a decision based the query string 
    const sessionResponse = await client.session()
    // use session data
    if (session.isLoggedIn === true) {
-    session.idTokenClaims?.sub
+     session.idTokenClaims?.sub
    }
    ```
 6. Logging out
@@ -75,3 +75,20 @@ on every load of the SPA. This function makes a decision based the query string 
      location.href = logoutResponse.logoutUrl;
    }
    ```
+   
+7. Implementing preemptive refresh. `session()`, `refresh()`, `endLogin()` and `onPageLoad()` functions return `accessTokenExpiresIn`
+   if the Authorization Server includes `expires_in` in token responses. This field contains number of seconds until an  
+   access token that is in the proxy cookie expires. This value can be used to preemptively refresh the access token.
+   After calling `onPageLoad()` and `refresh()`:
+   ```typescript
+   // const response = await client.onPageLoad(location.href)
+   // const response = await client.refresh()
+   if (response.accessTokenExpiresIn != null) {
+     const delay = Math.max(response.accessTokenExpiresIn - 2, 1)
+     setTimeout(
+       () => { client.refresh(); },
+       delay * 1000
+     );
+   }
+   ```
+   Note: This is just a simplified example. The timeout has to be cleared properly (before every refresh, or before logout).

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,11 +45,23 @@ export interface EndLoginRequest {
  * - `isLoggedIn` - a boolean flag indicationg whether a user is logged in
  * - `idTokenClaims` - an object containing ID token claims. This will be `null` if the user is
  *                     logged out; or the user is logged in but no ID token was issued.
+ * - `accessTokenExpiresIn` - expiration time of access token in seconds (`null` if no `expires_in` parameter
+ *                            was returned from the Authorization Server's token endpoint)
  */
 export interface SessionResponse {
   readonly isLoggedIn: boolean;
   readonly idTokenClaims?: any;
+  readonly accessTokenExpiresIn?: number;
+}
 
+
+/**
+ * Returned from the {@link OAuthAgentClient#refresh} function. Contains:
+ * - `accessTokenExpiresIn` - expiration time of access token in seconds (`null` if no `expires_in` parameter
+ *                            was returned from the Authorization Server's token endpoint)
+ */
+export interface RefreshResponse {
+  readonly accessTokenExpiresIn?: number;
 }
 
 /**
@@ -59,7 +71,6 @@ export interface SessionResponse {
  */
 export interface LogoutResponse {
   readonly logoutUrl?: string;
-
 }
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -13,7 +13,7 @@
  */
 
 import fetchMock from "jest-fetch-mock"
-import {Configuration, OAuthAgentClient, StartLoginRequest} from '../src';
+import {Configuration, OAuthAgentClient} from '../src';
 
 const serverUrl = 'https://example.com'
 const authzUrl = serverUrl + '/authz'
@@ -32,7 +32,8 @@ beforeEach(() => {
         is_logged_in: true,
         id_token_claims: {
           sub: 'login-end' // we are using 'sub' claims to distinguish between call to /login/end and /session (otherwise they return the same JSON structure)
-        }
+        },
+        access_token_expires_in: 300
       })
       return Promise.resolve(body)
     } else if (req.url.endsWith("/session")) {
@@ -40,7 +41,8 @@ beforeEach(() => {
         is_logged_in: true,
         id_token_claims: {
           sub: 'session'
-        }
+        },
+        access_token_expires_in: 300
       })
       return Promise.resolve(body)
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,6 +57,8 @@ describe('test onPageLoad() function', () => {
     const queryString = '?state=foo&code=bar'
     const response = await client.onPageLoad(redirectUri + queryString);
     expect(response.idTokenClaims?.sub).toBe('login-end');
+    expect(response.isLoggedIn).toBe(true);
+    expect(response.accessTokenExpiresIn).toBe(300);
   });
 
   test('when url contains state and error, /login/end should be called', async () => {
@@ -75,6 +77,8 @@ describe('test onPageLoad() function', () => {
     const queryString = '?response=eyjwt&state=foo'
     const response = await client.onPageLoad(redirectUri + queryString);
     expect(response.idTokenClaims?.sub).toBe('session');
+    expect(response.isLoggedIn).toBe(true);
+    expect(response.accessTokenExpiresIn).toBe(300);
   });
 
   test('when url contains only state, /session should be called', async () => {


### PR DESCRIPTION
A new response field `access_token_expires_in` was added to `session`, `refresh` and `login/end` endpoints. This PR is about adding that field to the responses of respective functions that call these endpoints. 