### PR TITLE
Add support for extra parameters in refresh requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Token Handler Assistant Changelog
 
-## [Pending]
+## [1.2.0] - 2025-05-06
  
 - Add support for extra parameters in refresh requests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Token Handler Assistant Changelog
 
+## [Pending]
+ 
+- Add support for extra parameters in refresh requests
+
 ## [1.1.0] - 2024-08-12
 
 - Send `token-handler-version` header in all requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curity/token-handler-js-assistant",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@curity/token-handler-js-assistant",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curity/token-handler-js-assistant",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Curity Token Handler JavaScript helper library",
   "main": "lib/token-handler-assistant-lib.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@
  *  limitations under the License.
  */
 
-export {StartLoginRequest, StartLoginResponse, EndLoginRequest, SessionResponse, RefreshResponse, LogoutResponse, OAuthAgentRemoteError} from './types'
+export {StartLoginRequest, StartLoginResponse, EndLoginRequest, SessionResponse, RefreshRequest, RefreshResponse, LogoutResponse, OAuthAgentRemoteError} from './types'
 export {Configuration, OAuthAgentClient} from './oauth-agent-client'

--- a/src/oauth-agent-client.ts
+++ b/src/oauth-agent-client.ts
@@ -16,6 +16,7 @@ import {
   EndLoginRequest,
   LogoutResponse,
   OAuthAgentRemoteError,
+  RefreshRequest,
   RefreshResponse,
   SessionResponse,
   StartLoginRequest,
@@ -48,13 +49,16 @@ export class OAuthAgentClient {
 
   /**
    * Refreshes the access token. Calls the `/refresh` endpoint.
+   * 
+   * @param request the refresh request possibly containing extra parameters
    *
    * @return the refresh token response possibly containing the new access token's expiration time
-   *
+   * 
    * @throws OAuthAgentRemoteError when OAuth Agent responded with an error
    */
-  async refresh(): Promise<RefreshResponse> {
-    const refreshResponse = await this.fetch("POST", "refresh")
+  async refresh(request?: RefreshRequest): Promise<RefreshResponse> {
+    const urlSearchParams = this.toUrlSearchParams(request?.extraRefreshParameters)
+    const refreshResponse = await this.fetch("POST", "refresh", urlSearchParams)
 
     return {
       accessTokenExpiresIn: refreshResponse.access_token_expires_in
@@ -162,7 +166,7 @@ export class OAuthAgentClient {
 
   }
 
-  private toUrlSearchParams(data: {[key: string]: string; } | undefined): URLSearchParams {
+  private toUrlSearchParams(data: { [key: string]: string; } | undefined): URLSearchParams {
     if (!data) {
       return new URLSearchParams()
     }
@@ -170,12 +174,12 @@ export class OAuthAgentClient {
   }
 
   private async fetch(method: string, path: string, content?: URLSearchParams): Promise<any> {
-    const headers= {
+    const headers = {
       accept: 'application/json',
       'token-handler-version': '1'
     } as Record<string, string>
 
-    if (path == 'login/start' || path == 'login/end') {
+    if (content && content.size !== 0) {
       headers["content-type"] = 'application/x-www-form-urlencoded'
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,6 @@
  * (such as `scope`, `login_hint` or `ui_locales`). These parameters will be used in the authorization request.
  * Each parameter has to be explicitly allowed in the configuration of the token handler application
  * in the Curity server.
- *
  */
 export interface StartLoginRequest {
   readonly extraAuthorizationParameters?: { [key: string]: string };
@@ -54,6 +53,17 @@ export interface SessionResponse {
   readonly accessTokenExpiresIn?: number;
 }
 
+/**
+ * Passed to {@link OAuthAgentClient#refresh} function.
+ */
+export interface RefreshRequest {
+  /**
+   * Extra parameters to be used in the token refresh request.
+   * Each parameter has to be explicitly allowed in the configuration of the token handler application
+   * in the Curity server.
+   */
+  readonly extraRefreshParameters?: { [key: string]: string };
+}
 
 /**
  * Returned from the {@link OAuthAgentClient#refresh} function. Contains:


### PR DESCRIPTION
Following up new support added in server version 10.2. Already did e2e tests with a local version of the package in the test SPA.